### PR TITLE
fix: Σ and Ø Note columns not updating on grade input

### DIFF
--- a/index.html
+++ b/index.html
@@ -1270,9 +1270,7 @@ function setGrade(key, val) {
     state.grades[key] = Math.max(0, Math.min(15, parseInt(val)));
   }
   renderResult();
-  // Re-render block1 errors only (avoid full re-render)
-  const { issues } = calcBlockI();
-  document.getElementById('block1-errors').innerHTML = issues.map(m => errorEl(m)).join('');
+  renderBlock1();
 }
 
 // ══════════════════════════════════════════════════════════════


### PR DESCRIPTION
**Bug:** Entering grades did not update the Σ (sum) and Ø Note columns in the grade table. Result panel was updated but the row display stayed static.

**Root cause:** `setGrade()` only called `renderResult()` but not `renderBlock1()`. The sum/note values are rendered as static HTML in the rows and need a re-render to update.

**Fix:** Call `renderBlock1()` after every grade change.