### PR TITLE
feat: Prüfungsfächer zusammenführen + LF-Gewichtung automatisieren (#7)

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,17 +7,18 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Matomo -->
   <script>
-   var _paq = window._paq = window._paq || [];
-   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-   _paq.push(['trackPageView']);
-   _paq.push(['enableLinkTracking']);
-   (function() {
-   var u="//matomo.intern.fari.cloud/";
-   _paq.push(['setTrackerUrl', u+'matomo.php']);
-   _paq.push(['setSiteId', '3']);
-   var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-   g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-   })();
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="//matomo.intern.fari.cloud/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '3']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
   </script>
   <!-- End Matomo Code -->
   <style>


### PR DESCRIPTION
Schließt #7

## Was wurde geändert

### Logik
- **Auto-Gewichtung**: `computeBestDoubled()` wählt automatisch die 2 von 3 LFs, die den höchsten Block-I-Score ergeben — kein manueller Schritt mehr nötig
- **`state.doubled` entfernt** — wird nur noch zur Laufzeit berechnet, nicht gespeichert
- **Backwards-kompatibel**: alter LocalStorage/JSON-Stand lädt sauber (unbekannte Felder werden ignoriert)

### UI
- **Steps 1 + 2 zusammengeführt** zu *"Prüfungsfächer wählen"*: LF-Auswahl, mündliche PFs und Basisfach-Konfiguration in einem Step
- **Doppelgewichtungs-Checkbox entfernt** (war manuell, jetzt automatisch)
- Steps neu nummeriert: 3→2, 4→3, 5→4

## Offen für @freddy-fari
- UI-Feinschliff (Layout, Abstände, Labels)
- Ev. Hinweis im Ergebnis anzeigen welche 2 LFs gewichtet wurden

/cc @matspi