### PR TITLE
feat: update course badges (LF/BF/PF/WF) and color-code Block I rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,6 +186,7 @@
           <span>Überblick über Block-I-Kurse. Genau 40 werden eingebracht</span>
           <span class="text-gray-300">·</span>
           <span class="font-bold text-blue-700 bg-blue-100 px-1.5 py-0.5 rounded">LF</span> Leistungsfach
+          <span class="font-bold text-amber-700 bg-amber-100 border border-amber-300 px-1.5 py-0.5 rounded">LF ×2</span> doppelt gewichtet
           <span class="font-bold text-violet-700 bg-violet-100 border border-violet-200 px-1.5 py-0.5 rounded">BF</span> Geprüftes Basisfach
           <span class="font-semibold text-slate-600 bg-slate-100 px-1.5 py-0.5 rounded">PF</span> Pflichtfach
           <span class="text-gray-400 bg-gray-50 border border-gray-200 px-1.5 py-0.5 rounded">WF</span> Wahlfach
@@ -1011,7 +1012,9 @@ function renderBlock1() {
         : `<span class="text-xs font-bold text-blue-700 bg-blue-100 px-1.5 py-0.5 rounded" title="Leistungsfach">LF</span>`
       : b1MpfIds.includes(sub.id)
         ? `<span class="text-xs font-bold text-violet-700 bg-violet-100 border border-violet-200 px-1 rounded" title="Geprüftes Basisfach">BF</span>`
-        : '';
+        : sub.requiredBlock1
+          ? `<span class="text-xs font-semibold text-slate-600 bg-slate-100 px-1 rounded" title="Pflichtfach">PF</span>`
+          : `<span class="text-xs text-gray-400 bg-gray-50 border border-gray-200 px-1 rounded" title="Wahlfach">WF</span>`;
     const sum = Array.from({length: sub.hj}, (_, j) => ptVal(`${sub.id}_${j+1}`) ?? 0).reduce((a, b) => a + b, 0);
     const avg = sub.hj > 0 ? sum / sub.hj : 0;
     const avgNote = POINTS_TO_NOTE[Math.round(avg)] || '–';


### PR DESCRIPTION
Closes #12

## Changes

### Step 2 – Kursübersicht
- Replaced `Pflicht` / `Block I` / `Reserve` badges with the proper terminology:
  - **LF** – Leistungsfach (blue, unchanged)
  - **BF** – Geprüftes Basisfach (violet) — for mündliche Prüfungsfächer
  - **PF** – Pflichtfach (slate) — all other required subjects
  - **WF** – Wahlfach (light gray) — optional / elective courses
- Added a compact legend row inline above the course list
- **Color-coded the 40 Block-I-selected courses**: green left border + light green background; non-selected rows are dimmed (opacity)

### Step 3 – Kursnoten
- Removed the now-redundant `Block I` and `Reserve` badges (the whole step is Block I — no need to label each row)
- Kept `LF ×2`, `LF`, and `BF` badges where meaningful
- Grade inputs for counted courses now have a subtle green border accent
- Non-selected (reserve) rows are slightly more dimmed for clarity

### No logic changes
All calculation logic is unchanged. Only visual presentation updated.