### PR TITLE
ui: new badge system — LF/BF/PF/WF, remove Block I + Reserve (#12)

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,18 @@
         </button>
       </div>
       <div id="step3-body" class="step-body px-5 pb-5">
-        <p class="text-xs text-gray-500 mb-4">Überblick über die geplanten Block-I-Kurse. Genau 40 Kurse müssen eingebracht werden.</p>
+        <p class="text-xs text-gray-500 mb-2">Überblick über die geplanten Block-I-Kurse. Genau 40 Kurse müssen eingebracht werden.</p>
+        <div class="flex flex-wrap gap-2 mb-4 text-xs">
+          <span class="font-bold text-blue-700 bg-blue-100 px-1.5 py-0.5 rounded">LF</span><span class="text-gray-500">Leistungsfach</span>
+          <span class="mx-1 text-gray-300">·</span>
+          <span class="font-bold text-amber-700 bg-amber-100 border border-amber-300 px-1.5 py-0.5 rounded">LF ×2</span><span class="text-gray-500">doppelt gewichtet</span>
+          <span class="mx-1 text-gray-300">·</span>
+          <span class="font-bold text-purple-700 bg-purple-100 border border-purple-200 px-1.5 py-0.5 rounded">BF</span><span class="text-gray-500">Geprüftes Basisfach</span>
+          <span class="mx-1 text-gray-300">·</span>
+          <span class="font-semibold text-green-700 bg-green-50 border border-green-200 px-1.5 py-0.5 rounded">PF</span><span class="text-gray-500">Pflichtfach</span>
+          <span class="mx-1 text-gray-300">·</span>
+          <span class="text-gray-500 bg-gray-100 border border-gray-200 px-1.5 py-0.5 rounded">WF</span><span class="text-gray-500">Wahlfach</span>
+        </div>
         <div id="overview-config" class="mb-3"></div>
         <div id="course-overview" class="space-y-1"></div>
         <div id="overview-errors" class="mt-2 space-y-1"></div>
@@ -911,15 +922,16 @@ function renderCourseOverview() {
   // Only show auto-required subjects in the main list (extras shown separately below)
   const rows = subs.filter(sub => !extraIds.includes(sub.id)).map(sub => {
     const b1 = inBlock1.has(sub.id);
+    const isMPF = state.mpf.includes(sub.id);
     const tag = sub.isLF
       ? doubled.includes(sub.id)
         ? `<span class="text-xs font-bold text-amber-700 bg-amber-100 border border-amber-300 px-1.5 py-0.5 rounded">LF ×2</span>`
         : `<span class="text-xs font-bold text-blue-700 bg-blue-100 px-1.5 py-0.5 rounded">LF</span>`
-      : sub.requiredBlock1
-        ? `<span class="text-xs text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded">Pflicht</span>`
-        : b1
-          ? `<span class="text-xs text-teal-700 bg-teal-50 border border-teal-200 px-1.5 py-0.5 rounded">Block I</span>`
-          : `<span class="text-xs text-gray-400 bg-gray-50 border border-gray-200 px-1.5 py-0.5 rounded">Reserve</span>`;
+      : isMPF
+        ? `<span class="text-xs font-bold text-purple-700 bg-purple-100 border border-purple-200 px-1.5 py-0.5 rounded">BF</span>`
+        : sub.requiredBlock1
+          ? `<span class="text-xs font-semibold text-green-700 bg-green-50 border border-green-200 px-1.5 py-0.5 rounded">PF</span>`
+          : `<span class="text-xs text-gray-500 bg-gray-100 border border-gray-200 px-1.5 py-0.5 rounded">WF</span>`;
     const hjBadges = Array.from({length: sub.hj}, (_, j) =>
       `<span class="text-xs text-gray-500 bg-gray-100 px-1 rounded">HJ${j+1}</span>`
     ).join(' ');
@@ -993,13 +1005,16 @@ function renderBlock1() {
   el.innerHTML = subs.map(sub => {
     const b1 = inBlock1.has(sub.id);
     const rowBg = sub.isLF ? 'bg-blue-50 border border-blue-100' : b1 ? 'bg-gray-50' : 'bg-gray-50 opacity-60';
+    const isMPF = state.mpf.includes(sub.id);
     const lfBadge = sub.isLF
       ? doubled.includes(sub.id)
         ? `<span class="text-xs font-bold text-amber-700 bg-amber-100 border border-amber-300 px-1.5 py-0.5 rounded">LF ×2</span>`
         : `<span class="text-xs font-bold text-blue-700 bg-blue-100 px-1.5 py-0.5 rounded">LF</span>`
-      : b1
-        ? `<span class="text-xs text-teal-700 bg-teal-50 border border-teal-200 px-1 rounded">Block I</span>`
-        : `<span class="text-xs text-gray-400 bg-gray-100 px-1 rounded">Reserve</span>`;
+      : isMPF
+        ? `<span class="text-xs font-bold text-purple-700 bg-purple-100 border border-purple-200 px-1.5 py-0.5 rounded">BF</span>`
+        : sub.requiredBlock1
+          ? `<span class="text-xs font-semibold text-green-700 bg-green-50 border border-green-200 px-1.5 py-0.5 rounded">PF</span>`
+          : `<span class="text-xs text-gray-500 bg-gray-100 border border-gray-200 px-1.5 py-0.5 rounded">WF</span>`;
     const sum = Array.from({length: sub.hj}, (_, j) => ptVal(`${sub.id}_${j+1}`) ?? 0).reduce((a, b) => a + b, 0);
     const avg = sub.hj > 0 ? sum / sub.hj : 0;
     const avgNote = POINTS_TO_NOTE[Math.round(avg)] || '–';


### PR DESCRIPTION
Closes #12

## Changes

### Badge-System (Step 2 – Kursübersicht)
- `LF` (blau) — Leistungsfach
- `LF ×2` (amber, bordered) — automatisch doppelt gewichtetes LF
- `BF` (lila) — Geprüftes Basisfach (mündliche Prüfungsfächer)
- `PF` (grün) — Pflichtfach (Basisfächer)
- `WF` (grau) — Wahlfach (Religion, Sport, freie Kurse)

Badge-Legende direkt unter dem Step-2-Header hinzugefügt.

### Step 3 – Block I Noten
- `Block I`-Badge entfernt (alle Kurse in Step 3 sind per Definition Block-I-Kurse)
- `Reserve`-Badge entfernt — durch `WF` ersetzt, das inhaltlich klarer ist
- Gleiche Farblogik wie in Step 2

**Hinweis:** Der Auto-Select der besten 40 Kurse (ebenfalls in #12 erwähnt) ist ein separates Feature, das Cindys Input braucht — werde ein eigenes Issue/Kommentar dafür anlegen.

@matspi ready for review 🙏