### PR TITLE
fix: persist Block I grades to localStorage on input

### DIFF
--- a/index.html
+++ b/index.html
@@ -1253,6 +1253,7 @@ function setGrade(key, val) {
   }
   renderResult();
   renderBlock1();
+  persistState();
 }
 
 // ══════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #15

## Root Cause

`setGrade()` (called by every Block I grade input) only called `renderResult()` and `renderBlock1()` to avoid a full re-render — but that bypassed `persistState()`, which only lives in `renderAll()`.

Block II inputs use inline `onchange="…;renderAll()"` so they were unaffected.

## Fix

One-line: call `persistState()` at the end of `setGrade()`.