### PR TITLE
feat: add Seminarkurse as selectable Wahlfach in Block I

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,7 +398,11 @@ const SUBJECTS_RAW = [
   { id: 'nwt',              name: 'NwT',                af: AF.III, lfOk: false, isFS: false, isNW: false },
   { id: 'informatik',       name: 'Informatik',         af: AF.III, lfOk: false, isFS: false, isNW: false },
   // NONE
-  { id: 'sport',            name: 'Sport',              af: AF.NONE, lfOk: true, isFS: false, isNW: false },
+  { id: 'sport',            name: 'Sport',              af: AF.NONE, lfOk: true,  isFS: false, isNW: false, isSeminar: false },
+  // Seminare — 2 HJ, zählen als 2 Kurse in Block I (Leitfaden §1.2)
+  { id: 'seminar_1',        name: 'Seminar 1',          af: AF.NONE, lfOk: false, isFS: false, isNW: false, isSeminar: true  },
+  { id: 'seminar_2',        name: 'Seminar 2',          af: AF.NONE, lfOk: false, isFS: false, isNW: false, isSeminar: true  },
+  { id: 'seminar_3',        name: 'Seminar 3',          af: AF.NONE, lfOk: false, isFS: false, isNW: false, isSeminar: true  },
 ];
 
 const SUBJECTS = [...SUBJECTS_RAW].sort((a, b) => a.name.localeCompare(b.name, 'de'));
@@ -974,10 +978,13 @@ function renderCourseOverview() {
   }).join('');
 
   const remaining = MIN_COURSES - totalCourses;
-  const addBtn = `<button onclick="addExtraCourse()" class="mt-2 text-sm text-blue-600 hover:text-blue-800 font-semibold flex items-center gap-1">
-      <span class="text-lg leading-none">+</span> Weiteres Fach hinzufügen
-      ${remaining > 0 ? `<span class="text-xs text-orange-500 font-normal">(noch ${remaining} Kurs${remaining !== 1 ? 'e' : ''} bis Minimum)</span>` : ''}
-    </button>`;
+  const addBtn = `<div class="mt-2 flex flex-col gap-1">
+      <button onclick="addExtraCourse()" class="text-sm text-blue-600 hover:text-blue-800 font-semibold flex items-center gap-1">
+        <span class="text-lg leading-none">+</span> Weiteres Fach hinzufügen
+        ${remaining > 0 ? `<span class="text-xs text-orange-500 font-normal">(noch ${remaining} Kurs${remaining !== 1 ? 'e' : ''} bis Minimum)</span>` : ''}
+      </button>
+      <p class="text-xs text-gray-400">💡 Seminarkurse (Seminar 1–3) werden automatisch auf 2 Halbjahre gesetzt und zählen als 2 Kurse in Block I.</p>
+    </div>`;
 
   const summary = `<div class="mt-3 pt-3 border-t space-y-1">
     <div class="flex items-center justify-between">
@@ -1257,6 +1264,10 @@ function removeExtraCourse(i) {
 
 function updateExtraCourse(i, field, val) {
   state.extraCourses[i][field] = val;
+  // Seminare immer 2 Halbjahre (Leitfaden: Seminarkurs = 2 Kurse)
+  if (field === 'id' && val && subjectMap[val]?.isSeminar) {
+    state.extraCourses[i].hj = 2;
+  }
   renderAll();
 }
 


### PR DESCRIPTION
Closes #17

Per Leitfaden ABI BW 2028: Seminarkurse = 2 HJ, zählen als 2 Kurse in Block I.

- Seminar 1/2/3 zu SUBJECTS_RAW hinzugefügt
- updateExtraCourse() setzt HJ auto auf 2 bei Seminar-Auswahl
- Info-Hinweis in Freie-Wahl-Sektion
- Besondere Lernleistung (Seminar als Block-II-Ersatz) bewusst ausgeklammert