### PR TITLE
fix: Block I Formel — Nenner immer 40 + gedoppelte Kurse (closes #23)

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,9 +650,8 @@ function calcBlockI() {
     }
   }
 
-  const doubledCount = doubled.length * 4;
-  // Denominator is always 40 + doubled courses (PDF formula: fixed, not dependent on actual course count)
-  const denominator = 40 + doubledCount;
+  // Denominator: 40 fixed Kurse + 4 extra per doubled LF (BW Abi PDF formula)
+  const denominator = 40 + doubled.length * 4;
   const block1 = denominator > 0 ? Math.round((sumAll + sumDoubled) * 40 / denominator) : 0;
 
   if (totalPlanned < 42) issues.push(`Mindestens 42 Kurse belegen (aktuell ${totalPlanned})`);


### PR DESCRIPTION
Closes #23

**Bug:** Nenner war `coursesInBlock1 + doubledCount` — wenn weniger als 40 Kurse geplant, stimmte das Ergebnis nicht.

**Fix:** Nenner ist jetzt fix `40 + doubledCount` (laut PDF immer 48 bei 2 gedoppelten LFs).

**Beispiel:** 15 Punkte in einem LF×2 Kurs → vorher 26, jetzt korrekt 25.