### PR TITLE
feat: Wahlbogen-PDF Export (closes #57)

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,10 @@
         📂 Laden
         <input type="file" accept=".json" class="hidden" onchange="loadState(event)">
       </label>
+      <button onclick="generateWahlbogen()"
+              class="flex items-center gap-1.5 bg-green-600 hover:bg-green-500 text-white text-sm font-semibold px-3 py-1.5 rounded-lg transition-colors">
+        📋 Wahlbogen
+      </button>
       <button onclick="resetState()"
               class="flex items-center gap-1.5 bg-white/10 hover:bg-white/20 text-white text-sm font-semibold px-3 py-1.5 rounded-lg transition-colors">
         🗑️ Zurücksetzen
@@ -1630,6 +1634,283 @@ function toggleResultPanel() {
 
 restoreState();
 renderAll();
+
+// ══════════════════════════════════════════════════════════════
+//  WAHLBOGEN PDF EXPORT
+// ══════════════════════════════════════════════════════════════
+
+function generateWahlbogen() {
+  // Dynamisch laden – nur beim ersten Klick
+  if (typeof window.jspdf === 'undefined') {
+    const script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js';
+    script.onload = () => _buildWahlbogenPDF();
+    script.onerror = () => showToast('⚠ jsPDF konnte nicht geladen werden (kein Internet?)', true);
+    document.head.appendChild(script);
+  } else {
+    _buildWahlbogenPDF();
+  }
+}
+
+function _buildWahlbogenPDF() {
+  const { jsPDF } = window.jspdf;
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+
+  const lfs    = state.lf.filter(Boolean);
+  const mpfs   = state.mpf.filter(Boolean);
+  const allSubs = getBlock1Subjects();
+  const totalCourses = allSubs.reduce((s, sub) => s + sub.hj, 0);
+  const today  = new Date().toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+
+  const W = 210, PL = 15, PR = 15, CW = W - PL - PR; // A4, margins
+  let y = 18;
+
+  // ── Helpers ──────────────────────────────────────────────
+  const setFont = (style = 'normal', size = 10) => { doc.setFont('helvetica', style); doc.setFontSize(size); };
+  const text = (t, x, yy, opts) => doc.text(t, x, yy, opts);
+  const line = (x1, y1, x2, y2, color = [180,180,180]) => {
+    doc.setDrawColor(...color);
+    doc.line(x1, y1, x2, y2);
+  };
+  const rect = (x, yy, w, h, style = 'S', color = [180,180,180]) => {
+    doc.setDrawColor(...color);
+    doc.rect(x, yy, w, h, style);
+  };
+  const fillRect = (x, yy, w, h, color) => {
+    doc.setFillColor(...color);
+    doc.rect(x, yy, w, h, 'F');
+  };
+  const checkRow = () => {
+    if (y > 272) { doc.addPage(); y = 15; }
+  };
+
+  // ── Header ───────────────────────────────────────────────
+  fillRect(PL - 2, y - 7, CW + 4, 14, [30, 58, 138]); // blue-800
+  setFont('bold', 16);
+  doc.setTextColor(255, 255, 255);
+  text('Abitur BW 2028 – Wahlbogen', PL + 1, y);
+  setFont('normal', 9);
+  text('Kurswahl Qualifikationsphase', PL + 1, y + 5);
+  text(`Erstellt: ${today}`, W - PR - 1, y + 5, { align: 'right' });
+  doc.setTextColor(0, 0, 0);
+  y += 16;
+
+  // ── Schülerangaben ───────────────────────────────────────
+  setFont('bold', 9);
+  doc.setTextColor(60, 60, 60);
+  text('SCHÜLERANGABEN', PL, y);
+  doc.setTextColor(0, 0, 0);
+  y += 4;
+
+  const fieldW = (CW - 10) / 2;
+  // Name
+  setFont('normal', 8);
+  doc.setTextColor(100, 100, 100);
+  text('Name, Vorname', PL, y);
+  text('Klasse / Kurs', PL + fieldW + 10, y);
+  doc.setTextColor(0, 0, 0);
+  y += 1;
+  line(PL, y + 3, PL + fieldW, y + 3);
+  line(PL + fieldW + 10, y + 3, PL + fieldW + 10 + fieldW, y + 3);
+  y += 7;
+
+  // Schule
+  doc.setTextColor(100, 100, 100);
+  text('Schule', PL, y);
+  doc.setTextColor(0, 0, 0);
+  y += 1;
+  line(PL, y + 3, W - PR, y + 3);
+  y += 9;
+
+  // ── Divider ──────────────────────────────────────────────
+  const divider = (label) => {
+    fillRect(PL - 2, y, CW + 4, 6, [241, 245, 249]); // slate-100
+    setFont('bold', 8);
+    doc.setTextColor(30, 64, 175); // blue-800
+    text(label, PL, y + 4.2);
+    doc.setTextColor(0, 0, 0);
+    y += 8;
+  };
+
+  // ── Prüfungsfächer ───────────────────────────────────────
+  divider('PRÜFUNGSFÄCHER (Block II)');
+
+  // Tabellenkopf
+  const col = { name: PL, af: PL + 70, typ: PL + 90, leer: PL + 115 };
+  setFont('bold', 7.5);
+  doc.setTextColor(80, 80, 80);
+  text('Fach', col.name, y);
+  text('AF', col.af, y);
+  text('Art', col.typ, y);
+  text('Bemerkung', col.leer, y);
+  doc.setTextColor(0, 0, 0);
+  y += 1;
+  line(PL - 1, y, W - PR + 1, y, [100, 100, 100]);
+  y += 3;
+
+  const pruefRows = [
+    ...lfs.map((id, i) => ({ label: subjectName(id), af: `AF ${subjectAF(id) || '–'}`, typ: `LF${i+1} (schriftlich)` })),
+    ...mpfs.map((id, i) => ({ label: subjectName(id), af: `AF ${subjectAF(id) || '–'}`, typ: `mPF${i+1} (mündlich)` })),
+  ];
+
+  for (const row of pruefRows) {
+    checkRow();
+    const rowBg = pruefRows.indexOf(row) % 2 === 0 ? [248,250,252] : [255,255,255];
+    fillRect(PL - 1, y - 3, CW + 2, 6, rowBg);
+    setFont(row.typ.startsWith('LF') ? 'bold' : 'normal', 9);
+    text(row.label, col.name, y);
+    setFont('normal', 8);
+    doc.setTextColor(80, 80, 80);
+    text(row.af, col.af, y);
+    doc.setTextColor(50, 100, 200);
+    text(row.typ, col.typ, y);
+    doc.setTextColor(0, 0, 0);
+    y += 6.5;
+  }
+
+  y += 3;
+
+  // ── Block I Fächerliste ──────────────────────────────────
+  divider('BLOCK I – KURSWAHL QUALIFIKATIONSPHASE');
+
+  // Erläuterung
+  setFont('normal', 7);
+  doc.setTextColor(100, 100, 100);
+  text('LF = Leistungsfach  ·  BF = Geprüftes Basisfach  ·  PF = Pflichtfach  ·  PF* = opt. in Block I  ·  WF = Wahlfach', PL, y);
+  doc.setTextColor(0, 0, 0);
+  y += 5;
+
+  // Tabellenkopf
+  const c = { name: PL, typ: PL + 62, hj: [PL+82, PL+93, PL+104, PL+115], kurs: PL+128, bemerk: PL+141 };
+  setFont('bold', 7.5);
+  doc.setTextColor(80, 80, 80);
+  text('Fach', c.name, y);
+  text('Typ', c.typ, y);
+  for (let i = 0; i < 4; i++) text(`HJ${i+1}`, c.hj[i], y, { align: 'center' });
+  text('Kurse', c.kurs, y, { align: 'center' });
+  text('Bemerkung', c.bemerk, y);
+  doc.setTextColor(0, 0, 0);
+  y += 1;
+  line(PL - 1, y, W - PR + 1, y, [100, 100, 100]);
+  y += 3;
+
+  const mpfIds = state.mpf.filter(Boolean);
+
+  let rowIdx = 0;
+  for (const sub of allSubs) {
+    checkRow();
+
+    const rowBg = rowIdx % 2 === 0 ? [248,250,252] : [255,255,255];
+    fillRect(PL - 1, y - 3, CW + 2, 6.5, rowBg);
+
+    // Fachname
+    setFont(sub.isLF ? 'bold' : 'normal', 9);
+    text(subjectName(sub.id), c.name, y);
+
+    // Typ-Badge
+    let typLabel, typColor;
+    if (sub.isLF)                       { typLabel = 'LF';  typColor = [30,64,175]; }
+    else if (mpfIds.includes(sub.id))   { typLabel = 'BF';  typColor = [109,40,217]; }
+    else if (sub.mandatory)             { typLabel = 'PF';  typColor = [71,85,105]; }
+    else if (sub.isPflicht)             { typLabel = 'PF*'; typColor = [100,116,139]; }
+    else                                { typLabel = 'WF';  typColor = [156,163,175]; }
+
+    const typX = c.typ;
+    fillRect(typX - 0.5, y - 3, 13, 5, [...typColor.map(v => Math.min(v+170,255))]);
+    setFont('bold', 7);
+    doc.setTextColor(...typColor);
+    text(typLabel, typX + 6, y - 0.5, { align: 'center' });
+    doc.setTextColor(0, 0, 0);
+
+    // HJ-Kästchen (angekreuzt wenn aktiv, leer wenn Optional)
+    const requiredCount = sub.mandatory ? (sub.mandatoryHj ?? sub.hj) : 0;
+    for (let j = 0; j < 4; j++) {
+      const bx = c.hj[j] - 2.5, by = y - 3.2, bw = 5, bh = 5;
+      if (j < sub.hj) {
+        const isMandatory = j < requiredCount;
+        rect(bx, by, bw, bh, 'S', isMandatory ? [50,100,200] : [160,160,160]);
+        if (isMandatory) {
+          // Häkchen
+          doc.setDrawColor(30, 100, 220);
+          doc.setLineWidth(0.5);
+          doc.line(bx+0.8, by+2.5, bx+2, by+4);
+          doc.line(bx+2, by+4, bx+4.2, by+0.8);
+          doc.setLineWidth(0.2);
+          doc.setDrawColor(180,180,180);
+        }
+      } else {
+        // Außerhalb HJ-Bereich: ausgrauen
+        fillRect(bx, by, 5, 5, [230,230,230]);
+      }
+    }
+
+    // Kurse
+    setFont('bold', 8);
+    doc.setTextColor(30, 64, 175);
+    text(String(sub.hj), c.kurs + 2, y, { align: 'center' });
+    doc.setTextColor(0, 0, 0);
+
+    // Bemerkung (z.B. Seminar)
+    if (sub.isSeminar) {
+      setFont('italic', 7);
+      doc.setTextColor(120,120,120);
+      text('Seminarkurs', c.bemerk, y);
+      doc.setTextColor(0,0,0);
+    }
+    if (sub.mandatoryHj && sub.mandatoryHj < sub.hj) {
+      setFont('italic', 7);
+      doc.setTextColor(120,120,120);
+      text(`mind. ${sub.mandatoryHj} HJ angerechnet`, c.bemerk, y);
+      doc.setTextColor(0,0,0);
+    }
+
+    y += 6.5;
+    rowIdx++;
+  }
+
+  // Linie
+  y += 1;
+  line(PL - 1, y, W - PR + 1, y, [100,100,100]);
+  y += 5;
+
+  // Summe
+  checkRow();
+  setFont('bold', 9);
+  const ok40 = totalCourses >= 40;
+  doc.setTextColor(ok40 ? 22 : 180, ok40 ? 101 : 40, ok40 ? 52 : 40);
+  text(`Gesamt belegte Kurse: ${totalCourses} ${ok40 ? '✓' : '(mind. 40 erforderlich)'}`, PL, y);
+  doc.setTextColor(0,0,0);
+  y += 5;
+
+  // Unterschriftenzeile
+  checkRow();
+  y += 4;
+  setFont('normal', 8);
+  doc.setTextColor(100,100,100);
+  const sigW = (CW - 15) / 3;
+  text('Ort / Datum', PL, y);
+  text('Unterschrift Schüler/in', PL + sigW + 7, y);
+  text('Unterschrift Eltern', PL + 2*(sigW + 7), y);
+  y += 1;
+  line(PL, y+4, PL + sigW, y+4);
+  line(PL + sigW + 7, y+4, PL + 2*sigW + 7, y+4);
+  line(PL + 2*(sigW+7), y+4, PL + 3*sigW + 7, y+4);
+  doc.setTextColor(0,0,0);
+  y += 12;
+
+  // ── Footer ───────────────────────────────────────────────
+  const pageCount = doc.getNumberOfPages();
+  for (let i = 1; i <= pageCount; i++) {
+    doc.setPage(i);
+    setFont('normal', 7);
+    doc.setTextColor(160,160,160);
+    text(`Erstellt mit abi-rechner.fari-software.de · ${today} · Seite ${i} / ${pageCount}`, W / 2, 290, { align: 'center' });
+    text('⚠ Kein offizielles Dokument. Maßgeblich ist die Prüfungsordnung deiner Schule.', W / 2, 294, { align: 'center' });
+  }
+
+  doc.save(`wahlbogen-abi2028-${today.replace(/\./g, '-')}.pdf`);
+  showToast('✓ Wahlbogen-PDF gespeichert');
+}
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1782,8 +1782,8 @@ function _buildWahlbogenPDF() {
   tc([0,0,0]); y += 5;
 
   const pruefFaecher = [
-    ...lfs.map((id,i) => ({ nr:i+1, af:`AF ${subjectAF(id)||'?'}`, name:subjectName(id), pruef:'schriftlich', isLF:true })),
-    ...mpfs.map((id,i) => ({ nr:lfs.length+i+1, af:`AF ${subjectAF(id)||'?'}`, name:subjectName(id), pruef:'mündlich', isLF:false })),
+    ...lfs.map((id,i) => ({ nr:i+1, af:`AF ${subjectAF(id)||'?'}`, name:subjectName(id), typ:'Leistungsfach', pruef:'schriftlich', isLF:true })),
+    ...mpfs.map((id,i) => ({ nr:lfs.length+i+1, af:`AF ${subjectAF(id)||'?'}`, name:subjectName(id), typ:'Basisfach', pruef:'mündlich', isLF:false })),
   ];
   while (pruefFaecher.length < 5) pruefFaecher.push({ nr:pruefFaecher.length+1, af:'', name:'', pruef:'', isLF:false });
 
@@ -1796,10 +1796,12 @@ function _buildWahlbogenPDF() {
     sf(pf.isLF?'bold':'normal', 8.5);
     tc(pf.isLF?[30,64,175]:pf.pruef?[60,60,60]:[180,180,180]);
     tx(pf.name, ML+24, y+4);
-    if (pf.pruef) {
-      sf('bold', 7);
+    if (pf.typ) {
+      sf('normal', 6.5);
       tc(pf.isLF?[30,64,175]:[109,40,217]);
-      tx(pf.pruef, ML+68, y+4);
+      tx(pf.typ, ML+68, y+2.2);
+      sf('bold', 7);
+      tx(pf.pruef, ML+68, y+5.2);
     }
     tc([0,0,0]); lw(0.15);
     ln(ML, y+5.5, ML+PF_W, y+5.5, [200,200,200]);

--- a/index.html
+++ b/index.html
@@ -1803,22 +1803,6 @@ function _buildWahlbogenPDF() {
   }
   const pfY1 = y;
 
-  // Schülerangaben box (right, same height)
-  lw(0.4); br(SA_X, pfY0, SA_W, pfY1-pfY0, [0,0,0]);
-  fr(SA_X, pfY0, SA_W, 6.5, [200,215,240]);
-  sf('bold', 8); tc([0,0,100]);
-  tx('Schülerangaben', SA_X+SA_W/2, pfY0+4.5, { align:'center' });
-  tc([0,0,0]);
-
-  const saFields = ['Name, Vorname, geb.','Klasse/KG, Tutor','Sprachenfolge, Profil','Konfession','Sch.-ID.'];
-  let fy = pfY0+6.5;
-  for (const f of saFields) {
-    sf('normal', 7); tc([120,120,120]);
-    tx(f, SA_X+2, fy+3.5);
-    lw(0.15); ln(SA_X, fy+5, SA_X+SA_W, fy+5, [180,180,180]);
-    tc([0,0,0]); fy += 5;
-  }
-
   y = pfY1 + 4;
 
   // ══ MAIN TABLE HEADER ═══════════════════════════════════════
@@ -1915,10 +1899,22 @@ function _buildWahlbogenPDF() {
     }
 
     // J1.1 / J1.2 / J2.1 / J2.2 checkboxes
+    // hjStart: 1 = J1 (HJ 1+2), 3 = J2 (HJ 3+4)
     const hjCols = [COL.j11,COL.j12,COL.j21,COL.j22];
+    const hjStart = studentMap[row.id]?.hjStart ?? 1; // 1-based
     for (let i=0; i<4; i++) {
+      const hjIndex = i+1; // 1..4
       const cx = hjCols[i]+5.5-2;
-      const cbS = !st.selected ? 'empty' : i<st.hj ? 'checked' : 'na';
+      let cbS;
+      if (!st.selected) {
+        cbS = 'empty';
+      } else if (hjIndex >= hjStart && hjIndex < hjStart + st.hj) {
+        cbS = 'checked';
+      } else if (st.hj < 4) {
+        cbS = 'na'; // outside the allocated HJ range
+      } else {
+        cbS = 'empty';
+      }
       checkbox(cx, y+1, 3.5, cbS);
     }
 

--- a/index.html
+++ b/index.html
@@ -170,9 +170,9 @@
         📂 Laden
         <input type="file" accept=".json" class="hidden" onchange="loadState(event)">
       </label>
-      <button onclick="generateWahlbogen()"
-              class="flex items-center gap-1.5 bg-green-600 hover:bg-green-500 text-white text-sm font-semibold px-3 py-1.5 rounded-lg transition-colors">
-        📋 Wahlbogen
+      <button id="pdf-export-btn" onclick="generateWahlbogen()"
+              class="hidden flex items-center gap-1.5 bg-green-600 hover:bg-green-500 text-white text-sm font-semibold px-3 py-1.5 rounded-lg transition-colors">
+        📄 PDF Export
       </button>
       <button onclick="resetState()"
               class="flex items-center gap-1.5 bg-white/10 hover:bg-white/20 text-white text-sm font-semibold px-3 py-1.5 rounded-lg transition-colors">
@@ -1427,6 +1427,12 @@ function renderAll() {
   renderBlock1();
   renderBlock2();
   renderResult();
+  const pdfExportBtn = document.getElementById('pdf-export-btn');
+  if (pdfExportBtn) {
+    const hasConfigErrors = validateConfig().length > 0;
+    pdfExportBtn.classList.toggle('hidden', hasConfigErrors);
+    pdfExportBtn.classList.toggle('flex', !hasConfigErrors);
+  }
   persistState();
 }
 

--- a/index.html
+++ b/index.html
@@ -1777,29 +1777,33 @@ function _buildWahlbogenPDF() {
 
   sf('bold', 6.5); tc([80,80,80]);
   tx('Nr.', ML+2, y+3.5); tx('(L)', ML+10, y+3.5);
-  tx('Fach', ML+24, y+3.5); tx('s/m', ML+72, y+3.5);
+  tx('Fach', ML+24, y+3.5); tx('Prüfung', ML+68, y+3.5);
   lw(0.25); ln(ML, y+5, ML+PF_W, y+5, [150,150,150]);
   tc([0,0,0]); y += 5;
 
   const pruefFaecher = [
-    ...lfs.map((id,i) => ({ nr:i+1, af:`(${['I','II','III'][subjectAF(id)-1]||'?'})`, name:subjectName(id), sm:'s' })),
-    ...mpfs.map((id,i) => ({ nr:lfs.length+i+1, af:'', name:subjectName(id), sm:'m**' })),
+    ...lfs.map((id,i) => ({ nr:i+1, af:`AF ${subjectAF(id)||'?'}`, name:subjectName(id), pruef:'schriftlich', isLF:true })),
+    ...mpfs.map((id,i) => ({ nr:lfs.length+i+1, af:`AF ${subjectAF(id)||'?'}`, name:subjectName(id), pruef:'mündlich', isLF:false })),
   ];
-  while (pruefFaecher.length < 5) pruefFaecher.push({ nr:pruefFaecher.length+1, af:'', name:'', sm:'' });
+  while (pruefFaecher.length < 5) pruefFaecher.push({ nr:pruefFaecher.length+1, af:'', name:'', pruef:'', isLF:false });
 
   for (const pf of pruefFaecher) {
-    fr(ML, y, PF_W, 5, pf.nr%2===0?[248,250,252]:[255,255,255]);
+    fr(ML, y, PF_W, 5.5, pf.nr%2===0?[248,250,252]:[255,255,255]);
     sf('bold', 8); tc([0,0,0]);
-    tx(pf.nr+'.', ML+2, y+3.5);
+    tx(pf.nr+'.', ML+2, y+4);
     sf('normal', 7); tc([80,80,80]);
-    tx(pf.af, ML+10, y+3.5);
-    sf(pf.sm==='s'?'bold':'normal', 8.5); tc(pf.sm==='s'?[30,64,175]:[60,60,60]);
-    tx(pf.name, ML+24, y+3.5);
-    sf('bold', 7.5); tc([109,40,217]);
-    tx(pf.sm, ML+72, y+3.5);
+    tx(pf.af, ML+10, y+4);
+    sf(pf.isLF?'bold':'normal', 8.5);
+    tc(pf.isLF?[30,64,175]:pf.pruef?[60,60,60]:[180,180,180]);
+    tx(pf.name, ML+24, y+4);
+    if (pf.pruef) {
+      sf('bold', 7);
+      tc(pf.isLF?[30,64,175]:[109,40,217]);
+      tx(pf.pruef, ML+68, y+4);
+    }
     tc([0,0,0]); lw(0.15);
-    ln(ML, y+5, ML+PF_W, y+5, [200,200,200]);
-    y += 5;
+    ln(ML, y+5.5, ML+PF_W, y+5.5, [200,200,200]);
+    y += 5.5;
   }
   const pfY1 = y;
 

--- a/index.html
+++ b/index.html
@@ -1695,32 +1695,7 @@ function _buildWahlbogenPDF() {
   doc.setTextColor(0, 0, 0);
   y += 16;
 
-  // ── Schülerangaben ───────────────────────────────────────
-  setFont('bold', 9);
-  doc.setTextColor(60, 60, 60);
-  text('SCHÜLERANGABEN', PL, y);
-  doc.setTextColor(0, 0, 0);
-  y += 4;
-
-  const fieldW = (CW - 10) / 2;
-  // Name
-  setFont('normal', 8);
-  doc.setTextColor(100, 100, 100);
-  text('Name, Vorname', PL, y);
-  text('Klasse / Kurs', PL + fieldW + 10, y);
-  doc.setTextColor(0, 0, 0);
-  y += 1;
-  line(PL, y + 3, PL + fieldW, y + 3);
-  line(PL + fieldW + 10, y + 3, PL + fieldW + 10 + fieldW, y + 3);
-  y += 7;
-
-  // Schule
-  doc.setTextColor(100, 100, 100);
-  text('Schule', PL, y);
-  doc.setTextColor(0, 0, 0);
-  y += 1;
-  line(PL, y + 3, W - PR, y + 3);
-  y += 9;
+  y += 2;
 
   // ── Divider ──────────────────────────────────────────────
   const divider = (label) => {
@@ -1736,13 +1711,12 @@ function _buildWahlbogenPDF() {
   divider('PRÜFUNGSFÄCHER (Block II)');
 
   // Tabellenkopf
-  const col = { name: PL, af: PL + 70, typ: PL + 90, leer: PL + 115 };
+  const col = { name: PL, af: PL + 70, typ: PL + 90 };
   setFont('bold', 7.5);
   doc.setTextColor(80, 80, 80);
   text('Fach', col.name, y);
   text('AF', col.af, y);
   text('Art', col.typ, y);
-  text('Bemerkung', col.leer, y);
   doc.setTextColor(0, 0, 0);
   y += 1;
   line(PL - 1, y, W - PR + 1, y, [100, 100, 100]);
@@ -1781,14 +1755,13 @@ function _buildWahlbogenPDF() {
   y += 5;
 
   // Tabellenkopf
-  const c = { name: PL, typ: PL + 62, hj: [PL+82, PL+93, PL+104, PL+115], kurs: PL+128, bemerk: PL+141 };
+  const c = { name: PL, typ: PL + 62, hj: [PL+82, PL+93, PL+104, PL+115], kurs: PL+128 };
   setFont('bold', 7.5);
   doc.setTextColor(80, 80, 80);
   text('Fach', c.name, y);
   text('Typ', c.typ, y);
   for (let i = 0; i < 4; i++) text(`HJ${i+1}`, c.hj[i], y, { align: 'center' });
   text('Kurse', c.kurs, y, { align: 'center' });
-  text('Bemerkung', c.bemerk, y);
   doc.setTextColor(0, 0, 0);
   y += 1;
   line(PL - 1, y, W - PR + 1, y, [100, 100, 100]);
@@ -1850,19 +1823,7 @@ function _buildWahlbogenPDF() {
     text(String(sub.hj), c.kurs + 2, y, { align: 'center' });
     doc.setTextColor(0, 0, 0);
 
-    // Bemerkung (z.B. Seminar)
-    if (sub.isSeminar) {
-      setFont('italic', 7);
-      doc.setTextColor(120,120,120);
-      text('Seminarkurs', c.bemerk, y);
-      doc.setTextColor(0,0,0);
-    }
-    if (sub.mandatoryHj && sub.mandatoryHj < sub.hj) {
-      setFont('italic', 7);
-      doc.setTextColor(120,120,120);
-      text(`mind. ${sub.mandatoryHj} HJ angerechnet`, c.bemerk, y);
-      doc.setTextColor(0,0,0);
-    }
+
 
     y += 6.5;
     rowIdx++;
@@ -1882,21 +1843,7 @@ function _buildWahlbogenPDF() {
   doc.setTextColor(0,0,0);
   y += 5;
 
-  // Unterschriftenzeile
-  checkRow();
-  y += 4;
-  setFont('normal', 8);
-  doc.setTextColor(100,100,100);
-  const sigW = (CW - 15) / 3;
-  text('Ort / Datum', PL, y);
-  text('Unterschrift Schüler/in', PL + sigW + 7, y);
-  text('Unterschrift Eltern', PL + 2*(sigW + 7), y);
-  y += 1;
-  line(PL, y+4, PL + sigW, y+4);
-  line(PL + sigW + 7, y+4, PL + 2*sigW + 7, y+4);
-  line(PL + 2*(sigW+7), y+4, PL + 3*sigW + 7, y+4);
-  doc.setTextColor(0,0,0);
-  y += 12;
+  y += 6;
 
   // ── Footer ───────────────────────────────────────────────
   const pageCount = doc.getNumberOfPages();

--- a/index.html
+++ b/index.html
@@ -1882,27 +1882,29 @@ function _buildWahlbogenPDF() {
     tx(row.belegp, COL.belp+1, y+3.8);
     tc([0,0,0]);
 
-    // Beleg. L/B checkbox
-    const lbCx = mid(COL.lb, COL.sm)-2;
+    // Beleg. L/B
+    const lbMid = mid(COL.lb, COL.sm);
     if (st.selected) {
-      checkbox(lbCx, y+1, 3.5, 'checked');
-      sf('bold', 5.5); tc([30,64,175]);
-      tx(st.isLF?'L':'B', lbCx+1.75, y+7, { align:'center' });
+      sf('bold', 8); tc(st.isLF ? [30,64,175] : [71,85,105]);
+      tx(st.isLF ? 'L' : 'B', lbMid, y+3.8, { align:'center' });
       tc([0,0,0]);
     } else {
-      checkbox(lbCx, y+1, 3.5, 'empty');
+      sf('normal', 7); tc([170,170,170]);
+      tx('–', lbMid, y+3.8, { align:'center' });
+      tc([0,0,0]);
     }
 
-    // Prüf. s/m checkbox
-    const smCx = mid(COL.sm, COL.j11)-2;
+    // Prüf. s/m
+    const smMid = mid(COL.sm, COL.j11);
     const isPruef = lfsSet.has(row.id)||mpfsSet.has(row.id);
     if (isPruef) {
-      checkbox(smCx, y+1, 3.5, 'checked');
-      sf('bold', 5.5); tc([109,40,217]);
-      tx(lfsSet.has(row.id)?'s':'m', smCx+1.75, y+7, { align:'center' });
+      sf('bold', 8); tc(lfsSet.has(row.id) ? [30,64,175] : [109,40,217]);
+      tx(lfsSet.has(row.id) ? 's' : 'm', smMid, y+3.8, { align:'center' });
       tc([0,0,0]);
     } else {
-      checkbox(smCx, y+1, 3.5, 'empty');
+      sf('normal', 7); tc([170,170,170]);
+      tx('–', smMid, y+3.8, { align:'center' });
+      tc([0,0,0]);
     }
 
     // J1.1 / J1.2 / J2.1 / J2.2 checkboxes

--- a/index.html
+++ b/index.html
@@ -1635,12 +1635,12 @@ function toggleResultPanel() {
 restoreState();
 renderAll();
 
+
 // ══════════════════════════════════════════════════════════════
 //  WAHLBOGEN PDF EXPORT
 // ══════════════════════════════════════════════════════════════
 
 function generateWahlbogen() {
-  // Dynamisch laden – nur beim ersten Klick
   if (typeof window.jspdf === 'undefined') {
     const script = document.createElement('script');
     script.src = 'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js';
@@ -1658,204 +1658,357 @@ function _buildWahlbogenPDF() {
 
   const lfs    = state.lf.filter(Boolean);
   const mpfs   = state.mpf.filter(Boolean);
-  const allSubs = getBlock1Subjects();
-  const totalCourses = allSubs.reduce((s, sub) => s + sub.hj, 0);
   const today  = new Date().toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+  const W = 210, ML = 10, MR = 10, CW = W - ML - MR;
 
-  const W = 210, PL = 15, PR = 15, CW = W - PL - PR; // A4, margins
-  let y = 18;
+  // ── Helpers ─────────────────────────────────────────────────
+  const sf = (style, size) => { doc.setFont('helvetica', style); doc.setFontSize(size); };
+  const tx = (t, x, y, opts) => doc.text(String(t), x, y, opts || {});
+  const ln = (x1,y1,x2,y2,rgb) => { doc.setDrawColor(...(rgb||[0,0,0])); doc.line(x1,y1,x2,y2); };
+  const fr = (x,y,w,h,rgb) => { doc.setFillColor(...rgb); doc.rect(x,y,w,h,'F'); };
+  const br = (x,y,w,h,rgb) => { doc.setDrawColor(...(rgb||[0,0,0])); doc.rect(x,y,w,h,'S'); };
+  const tc = (rgb) => doc.setTextColor(...rgb);
+  const lw = (w) => doc.setLineWidth(w);
 
-  // ── Helpers ──────────────────────────────────────────────
-  const setFont = (style = 'normal', size = 10) => { doc.setFont('helvetica', style); doc.setFontSize(size); };
-  const text = (t, x, yy, opts) => doc.text(t, x, yy, opts);
-  const line = (x1, y1, x2, y2, color = [180,180,180]) => {
-    doc.setDrawColor(...color);
-    doc.line(x1, y1, x2, y2);
-  };
-  const rect = (x, yy, w, h, style = 'S', color = [180,180,180]) => {
-    doc.setDrawColor(...color);
-    doc.rect(x, yy, w, h, style);
-  };
-  const fillRect = (x, yy, w, h, color) => {
-    doc.setFillColor(...color);
-    doc.rect(x, yy, w, h, 'F');
-  };
-  const checkRow = () => {
-    if (y > 272) { doc.addPage(); y = 15; }
-  };
-
-  // ── Header ───────────────────────────────────────────────
-  fillRect(PL - 2, y - 7, CW + 4, 14, [30, 58, 138]); // blue-800
-  setFont('bold', 16);
-  doc.setTextColor(255, 255, 255);
-  text('Abitur BW 2028 – Wahlbogen', PL + 1, y);
-  setFont('normal', 9);
-  text('Kurswahl Qualifikationsphase', PL + 1, y + 5);
-  text(`Erstellt: ${today}`, W - PR - 1, y + 5, { align: 'right' });
-  doc.setTextColor(0, 0, 0);
-  y += 16;
-
-  y += 2;
-
-  // ── Divider ──────────────────────────────────────────────
-  const divider = (label) => {
-    fillRect(PL - 2, y, CW + 4, 6, [241, 245, 249]); // slate-100
-    setFont('bold', 8);
-    doc.setTextColor(30, 64, 175); // blue-800
-    text(label, PL, y + 4.2);
-    doc.setTextColor(0, 0, 0);
-    y += 8;
+  // Small checkbox: state = 'checked' | 'empty' | 'na'
+  const checkbox = (x, y, size, cbState) => {
+    lw(0.25);
+    if (cbState === 'na') {
+      fr(x,y,size,size,[220,220,220]);
+      doc.setDrawColor(200,200,200); doc.rect(x,y,size,size,'S');
+    } else if (cbState === 'checked') {
+      fr(x,y,size,size,[219,234,254]);
+      doc.setDrawColor(59,130,246); doc.rect(x,y,size,size,'S');
+      lw(0.5); doc.setDrawColor(29,78,216);
+      doc.line(x+0.6, y+size*0.52, x+size*0.4, y+size*0.82);
+      doc.line(x+size*0.4, y+size*0.82, x+size-0.4, y+size*0.18);
+      lw(0.25);
+    } else {
+      doc.setDrawColor(160,160,160); doc.rect(x,y,size,size,'S');
+    }
   };
 
-  // ── Prüfungsfächer ───────────────────────────────────────
-  divider('PRÜFUNGSFÄCHER (Block II)');
+  // ── Column positions ─────────────────────────────────────────
+  const COL = {
+    af:   ML,          // width 18 — merged AF label
+    fach: ML+18,       // width 40 — subject name
+    belp: ML+58,       // width 21 — Belegpflicht
+    lb:   ML+79,       // width 11 — Beleg. L/B
+    sm:   ML+90,       // width 11 — Prüf. s/m
+    j11:  ML+101,      // width 11
+    j12:  ML+112,      // width 11
+    j21:  ML+123,      // width 11
+    j22:  ML+134,      // width 11
+    kurs: ML+145,      // width 14
+    end:  ML+CW,
+  };
+  const ROW_H = 5.5;
 
-  // Tabellenkopf
-  const col = { name: PL, af: PL + 70, typ: PL + 90 };
-  setFont('bold', 7.5);
-  doc.setTextColor(80, 80, 80);
-  text('Fach', col.name, y);
-  text('AF', col.af, y);
-  text('Art', col.typ, y);
-  doc.setTextColor(0, 0, 0);
-  y += 1;
-  line(PL - 1, y, W - PR + 1, y, [100, 100, 100]);
-  y += 3;
-
-  const pruefRows = [
-    ...lfs.map((id, i) => ({ label: subjectName(id), af: `AF ${subjectAF(id) || '–'}`, typ: `LF${i+1} (schriftlich)` })),
-    ...mpfs.map((id, i) => ({ label: subjectName(id), af: `AF ${subjectAF(id) || '–'}`, typ: `mPF${i+1} (mündlich)` })),
+  // ── Subject catalogue (matches BW Wahlbogen structure) ────────
+  const CATALOGUE = [
+    { af:'I',   id:'deutsch',           name:'Deutsch',                  belegp:'4 Hj.' },
+    { af:'I',   id:'englisch',          name:'Englisch',                 belegp:'4 Hj.' },
+    { af:'I',   id:'franzoesisch',      name:'Französisch',              belegp:'4 Hj.' },
+    { af:'I',   id:'latein',            name:'Latein',                   belegp:'4 Hj.' },
+    { af:'I',   id:'griechisch',        name:'Griechisch',               belegp:'4 Hj.' },
+    { af:'I',   id:'russisch',          name:'Russisch',                 belegp:'4 Hj.' },
+    { af:'I',   id:'spanisch',          name:'Spanisch',                 belegp:'4 Hj.' },
+    { af:'I',   id:'italienisch',       name:'Italienisch',              belegp:'4 Hj.' },
+    { af:'I',   id:'chinesisch',        name:'Chinesisch',               belegp:'4 Hj.' },
+    { af:'I',   id:'kunst',             name:'Bildende Kunst',           belegp:'4 Hj., 1 Fach' },
+    { af:'I',   id:'musik',             name:'Musik',                    belegp:'4 Hj., 1 Fach' },
+    { af:'II',  id:'geschichte',        name:'Geschichte',               belegp:'4 Hj.' },
+    { af:'II',  id:'geographie',        name:'Geographie',               belegp:'2 o. 4 Hj.' },
+    { af:'II',  id:'gemeinschaftskunde',name:'Gemeinschaftskunde',       belegp:'2 o. 4 Hj.' },
+    { af:'II',  id:'religion',          name:'Religionslehre / Ethik',   belegp:'4 Hj.' },
+    { af:'II',  id:'wirtschaft',        name:'Wirtschaft',               belegp:'4 Hj.' },
+    { af:'III', id:'mathematik',        name:'Mathematik',               belegp:'4 Hj.' },
+    { af:'III', id:'biologie',          name:'Biologie',                 belegp:'4 Hj.' },
+    { af:'III', id:'chemie',            name:'Chemie',                   belegp:'4 Hj.' },
+    { af:'III', id:'physik',            name:'Physik',                   belegp:'4 Hj.' },
+    { af:'III', id:'nwt',               name:'NwT',                      belegp:'4 Hj.***' },
+    { af:'*',   id:'sport',             name:'Sport',                    belegp:'4 Hj.' },
+    { af:'W',   id:'informatik',        name:'Informatik',               belegp:'(2 o. 4)' },
+    { af:'W',   id:'seminar_1',         name:'Seminar 1',                belegp:'(2)' },
+    { af:'W',   id:'seminar_2',         name:'Seminar 2',                belegp:'(2)' },
+    { af:'W',   id:'seminar_3',         name:'Seminar 3',                belegp:'(2)' },
   ];
 
-  for (const row of pruefRows) {
-    checkRow();
-    const rowBg = pruefRows.indexOf(row) % 2 === 0 ? [248,250,252] : [255,255,255];
-    fillRect(PL - 1, y - 3, CW + 2, 6, rowBg);
-    setFont(row.typ.startsWith('LF') ? 'bold' : 'normal', 9);
-    text(row.label, col.name, y);
-    setFont('normal', 8);
-    doc.setTextColor(80, 80, 80);
-    text(row.af, col.af, y);
-    doc.setTextColor(50, 100, 200);
-    text(row.typ, col.typ, y);
-    doc.setTextColor(0, 0, 0);
-    y += 6.5;
+  // Add extra courses not in catalogue
+  const catalogueIds = new Set(CATALOGUE.map(r => r.id));
+  for (const ec of state.extraCourses) {
+    if (ec.id && !catalogueIds.has(ec.id)) {
+      CATALOGUE.push({ af:'W', id: ec.id, name: subjectName(ec.id), belegp:'' });
+    }
   }
 
-  y += 3;
+  const lfsSet  = new Set(lfs);
+  const mpfsSet = new Set(mpfs);
+  const studentSubs = getBlock1Subjects();
+  const studentMap  = Object.fromEntries(studentSubs.map(s => [s.id, s]));
 
-  // ── Block I Fächerliste ──────────────────────────────────
-  divider('BLOCK I – KURSWAHL QUALIFIKATIONSPHASE');
+  function stOf(id) {
+    const sub = studentMap[id];
+    if (!sub) return { selected:false, hj:0, isLF:false, isMPF:false };
+    return { selected:true, hj:sub.hj, isLF:lfsSet.has(id), isMPF:mpfsSet.has(id) };
+  }
 
-  // Erläuterung
-  setFont('normal', 7);
-  doc.setTextColor(100, 100, 100);
-  text('LF = Leistungsfach  ·  BF = Geprüftes Basisfach  ·  PF = Pflichtfach  ·  PF* = opt. in Block I  ·  WF = Wahlfach', PL, y);
-  doc.setTextColor(0, 0, 0);
+  let y = 14;
+
+  // ══ TITLE ═══════════════════════════════════════════════════
+  sf('bold', 13); tc([0,0,0]);
+  tx('Kurswahlbogen für die Jahrgangsstufen 1 und 2', W/2, y, { align:'center' });
+  y += 5;
+  sf('normal', 7); tc([80,80,80]);
+  tx('Abitur Baden-Württemberg 2028  ·  abi-rechner.fari-software.de  ·  ' + today + '  ·  Kein offizielles Dokument', W/2, y, { align:'center' });
+  tc([0,0,0]);
   y += 5;
 
-  // Tabellenkopf
-  const c = { name: PL, typ: PL + 62, hj: [PL+82, PL+93, PL+104, PL+115], kurs: PL+128 };
-  setFont('bold', 7.5);
-  doc.setTextColor(80, 80, 80);
-  text('Fach', c.name, y);
-  text('Typ', c.typ, y);
-  for (let i = 0; i < 4; i++) text(`HJ${i+1}`, c.hj[i], y, { align: 'center' });
-  text('Kurse', c.kurs, y, { align: 'center' });
-  doc.setTextColor(0, 0, 0);
-  y += 1;
-  line(PL - 1, y, W - PR + 1, y, [100, 100, 100]);
-  y += 3;
+  // ══ PRÜFUNGSFÄCHER + SCHÜLERANGABEN ═════════════════════════
+  const PF_W = 88, SA_X = ML+PF_W+4, SA_W = CW-PF_W-4;
+  const pfY0 = y;
 
-  const mpfIds = state.mpf.filter(Boolean);
+  // Prüfungsfächer box
+  lw(0.4); br(ML, y, PF_W, 38, [0,0,0]);
+  fr(ML, y, PF_W, 6.5, [200,215,240]);
+  sf('bold', 8); tc([0,0,100]);
+  tx('Prüfungsfächer', ML+PF_W/2, y+4.5, { align:'center' });
+  tc([0,0,0]); y += 6.5;
 
+  sf('bold', 6.5); tc([80,80,80]);
+  tx('Nr.', ML+2, y+3.5); tx('(L)', ML+10, y+3.5);
+  tx('Fach', ML+24, y+3.5); tx('s/m', ML+72, y+3.5);
+  lw(0.25); ln(ML, y+5, ML+PF_W, y+5, [150,150,150]);
+  tc([0,0,0]); y += 5;
+
+  const pruefFaecher = [
+    ...lfs.map((id,i) => ({ nr:i+1, af:`(${['I','II','III'][subjectAF(id)-1]||'?'})`, name:subjectName(id), sm:'s' })),
+    ...mpfs.map((id,i) => ({ nr:lfs.length+i+1, af:'', name:subjectName(id), sm:'m**' })),
+  ];
+  while (pruefFaecher.length < 5) pruefFaecher.push({ nr:pruefFaecher.length+1, af:'', name:'', sm:'' });
+
+  for (const pf of pruefFaecher) {
+    fr(ML, y, PF_W, 5, pf.nr%2===0?[248,250,252]:[255,255,255]);
+    sf('bold', 8); tc([0,0,0]);
+    tx(pf.nr+'.', ML+2, y+3.5);
+    sf('normal', 7); tc([80,80,80]);
+    tx(pf.af, ML+10, y+3.5);
+    sf(pf.sm==='s'?'bold':'normal', 8.5); tc(pf.sm==='s'?[30,64,175]:[60,60,60]);
+    tx(pf.name, ML+24, y+3.5);
+    sf('bold', 7.5); tc([109,40,217]);
+    tx(pf.sm, ML+72, y+3.5);
+    tc([0,0,0]); lw(0.15);
+    ln(ML, y+5, ML+PF_W, y+5, [200,200,200]);
+    y += 5;
+  }
+  const pfY1 = y;
+
+  // Schülerangaben box (right, same height)
+  lw(0.4); br(SA_X, pfY0, SA_W, pfY1-pfY0, [0,0,0]);
+  fr(SA_X, pfY0, SA_W, 6.5, [200,215,240]);
+  sf('bold', 8); tc([0,0,100]);
+  tx('Schülerangaben', SA_X+SA_W/2, pfY0+4.5, { align:'center' });
+  tc([0,0,0]);
+
+  const saFields = ['Name, Vorname, geb.','Klasse/KG, Tutor','Sprachenfolge, Profil','Konfession','Sch.-ID.'];
+  let fy = pfY0+6.5;
+  for (const f of saFields) {
+    sf('normal', 7); tc([120,120,120]);
+    tx(f, SA_X+2, fy+3.5);
+    lw(0.15); ln(SA_X, fy+5, SA_X+SA_W, fy+5, [180,180,180]);
+    tc([0,0,0]); fy += 5;
+  }
+
+  y = pfY1 + 4;
+
+  // ══ MAIN TABLE HEADER ═══════════════════════════════════════
+  const TH = 10;
+  lw(0.4); fr(ML, y, CW, TH, [210,220,240]);
+  br(ML, y, CW, TH, [0,0,0]);
+
+  // Vertical dividers in header
+  lw(0.3);
+  for (const x of [COL.fach,COL.belp,COL.lb,COL.sm,COL.j11,COL.j12,COL.j21,COL.j22,COL.kurs]) {
+    ln(x, y, x, y+TH, [80,80,120]);
+  }
+
+  sf('bold', 6.5); tc([0,0,80]);
+  tx('Aufgaben-\nfelder', ML+1, y+3);
+  tx('Fächer', COL.fach+1, y+6);
+  tx('Beleg-\npflicht', COL.belp+1, y+3);
+
+  // Centered col headers
+  const mid = (a,b) => (a+b)/2;
+  tx('Beleg.\nL/B',   mid(COL.lb,COL.sm),   y+3, { align:'center' });
+  tx('Prüf.\ns/m',   mid(COL.sm,COL.j11),   y+3, { align:'center' });
+  tx('Halbjahre',    mid(COL.j11,COL.kurs),  y+3, { align:'center' });
+  tx('J1.1', COL.j11+5.5, y+8, { align:'center' });
+  tx('J1.2', COL.j12+5.5, y+8, { align:'center' });
+  tx('J2.1', COL.j21+5.5, y+8, { align:'center' });
+  tx('J2.2', COL.j22+5.5, y+8, { align:'center' });
+  tx('Zahl\nKurse',  COL.kurs+7,  y+3, { align:'center' });
+  tc([0,0,0]);
+  y += TH;
+
+  // ══ TABLE ROWS ═══════════════════════════════════════════════
+  const VDIVIDERS = [COL.fach,COL.belp,COL.lb,COL.sm,COL.j11,COL.j12,COL.j21,COL.j22,COL.kurs,COL.end];
+  const afLabelMap = {
+    'I':   ['AF I','sprachlich-','literarisch-','künstlerisch'],
+    'II':  ['AF II','gesellschafts-','wissenschaft-','lich'],
+    'III': ['AF III','mathematisch-','naturwiss.-','technisch'],
+    '*':   ['AF*'],
+    'W':   ['Wahl-','bereich','(mögliche','Belegung)'],
+  };
+
+  const afRegions = [];
+  let prevAF = null, afY0 = y;
   let rowIdx = 0;
-  for (const sub of allSubs) {
-    checkRow();
 
-    const rowBg = rowIdx % 2 === 0 ? [248,250,252] : [255,255,255];
-    fillRect(PL - 1, y - 3, CW + 2, 6.5, rowBg);
-
-    // Fachname
-    setFont(sub.isLF ? 'bold' : 'normal', 9);
-    text(subjectName(sub.id), c.name, y);
-
-    // Typ-Badge
-    let typLabel, typColor;
-    if (sub.isLF)                       { typLabel = 'LF';  typColor = [30,64,175]; }
-    else if (mpfIds.includes(sub.id))   { typLabel = 'BF';  typColor = [109,40,217]; }
-    else if (sub.mandatory)             { typLabel = 'PF';  typColor = [71,85,105]; }
-    else if (sub.isPflicht)             { typLabel = 'PF*'; typColor = [100,116,139]; }
-    else                                { typLabel = 'WF';  typColor = [156,163,175]; }
-
-    const typX = c.typ;
-    fillRect(typX - 0.5, y - 3, 13, 5, [...typColor.map(v => Math.min(v+170,255))]);
-    setFont('bold', 7);
-    doc.setTextColor(...typColor);
-    text(typLabel, typX + 6, y - 0.5, { align: 'center' });
-    doc.setTextColor(0, 0, 0);
-
-    // HJ-Kästchen (angekreuzt wenn aktiv, leer wenn Optional)
-    const requiredCount = sub.mandatory ? (sub.mandatoryHj ?? sub.hj) : 0;
-    for (let j = 0; j < 4; j++) {
-      const bx = c.hj[j] - 2.5, by = y - 3.2, bw = 5, bh = 5;
-      if (j < sub.hj) {
-        const isMandatory = j < requiredCount;
-        rect(bx, by, bw, bh, 'S', isMandatory ? [50,100,200] : [160,160,160]);
-        if (isMandatory) {
-          // Häkchen
-          doc.setDrawColor(30, 100, 220);
-          doc.setLineWidth(0.5);
-          doc.line(bx+0.8, by+2.5, bx+2, by+4);
-          doc.line(bx+2, by+4, bx+4.2, by+0.8);
-          doc.setLineWidth(0.2);
-          doc.setDrawColor(180,180,180);
-        }
-      } else {
-        // Außerhalb HJ-Bereich: ausgrauen
-        fillRect(bx, by, 5, 5, [230,230,230]);
-      }
+  for (const row of CATALOGUE) {
+    if (row.af !== prevAF) {
+      if (prevAF !== null) afRegions.push({ af:prevAF, y0:afY0, y1:y });
+      afY0 = y; prevAF = row.af;
     }
 
-    // Kurse
-    setFont('bold', 8);
-    doc.setTextColor(30, 64, 175);
-    text(String(sub.hj), c.kurs + 2, y, { align: 'center' });
-    doc.setTextColor(0, 0, 0);
+    const st = stOf(row.id);
+    // Row background
+    let bg;
+    if (st.isLF)       bg = [219,234,254];
+    else if (st.isMPF) bg = [237,233,254];
+    else if (st.selected) bg = [240,253,244];
+    else               bg = rowIdx%2===0 ? [250,250,252] : [255,255,255];
 
+    fr(COL.fach, y, COL.end-COL.fach, ROW_H, bg);
 
+    // Subject name
+    sf(st.isLF?'bold':'normal', st.isLF?8:7.5);
+    tc(st.isLF?[30,64,175]:st.isMPF?[109,40,217]:[0,0,0]);
+    tx(row.name, COL.fach+1.5, y+3.8);
+    tc([0,0,0]);
 
-    y += 6.5;
+    // Belegpflicht
+    sf('normal', 6); tc([80,80,80]);
+    tx(row.belegp, COL.belp+1, y+3.8);
+    tc([0,0,0]);
+
+    // Beleg. L/B checkbox
+    const lbCx = mid(COL.lb, COL.sm)-2;
+    if (st.selected) {
+      checkbox(lbCx, y+1, 3.5, 'checked');
+      sf('bold', 5.5); tc([30,64,175]);
+      tx(st.isLF?'L':'B', lbCx+1.75, y+7, { align:'center' });
+      tc([0,0,0]);
+    } else {
+      checkbox(lbCx, y+1, 3.5, 'empty');
+    }
+
+    // Prüf. s/m checkbox
+    const smCx = mid(COL.sm, COL.j11)-2;
+    const isPruef = lfsSet.has(row.id)||mpfsSet.has(row.id);
+    if (isPruef) {
+      checkbox(smCx, y+1, 3.5, 'checked');
+      sf('bold', 5.5); tc([109,40,217]);
+      tx(lfsSet.has(row.id)?'s':'m', smCx+1.75, y+7, { align:'center' });
+      tc([0,0,0]);
+    } else {
+      checkbox(smCx, y+1, 3.5, 'empty');
+    }
+
+    // J1.1 / J1.2 / J2.1 / J2.2 checkboxes
+    const hjCols = [COL.j11,COL.j12,COL.j21,COL.j22];
+    for (let i=0; i<4; i++) {
+      const cx = hjCols[i]+5.5-2;
+      const cbS = !st.selected ? 'empty' : i<st.hj ? 'checked' : 'na';
+      checkbox(cx, y+1, 3.5, cbS);
+    }
+
+    // Kurse count
+    if (st.selected) {
+      sf('bold', 8); tc([30,64,175]);
+      tx(st.hj, COL.kurs+7, y+3.8, { align:'center' });
+      tc([0,0,0]);
+    }
+
+    // Row borders
+    lw(0.1);
+    ln(COL.fach, y+ROW_H, COL.end, y+ROW_H, [180,180,190]);
+    for (const vx of VDIVIDERS) ln(vx, y, vx, y+ROW_H, [160,165,185]);
+
+    y += ROW_H;
     rowIdx++;
   }
 
-  // Linie
-  y += 1;
-  line(PL - 1, y, W - PR + 1, y, [100,100,100]);
-  y += 5;
+  if (prevAF !== null) afRegions.push({ af:prevAF, y0:afY0, y1:y });
 
-  // Summe
-  checkRow();
-  setFont('bold', 9);
-  const ok40 = totalCourses >= 40;
-  doc.setTextColor(ok40 ? 22 : 180, ok40 ? 101 : 40, ok40 ? 52 : 40);
-  text(`Gesamt belegte Kurse: ${totalCourses} ${ok40 ? '✓' : '(mind. 40 erforderlich)'}`, PL, y);
-  doc.setTextColor(0,0,0);
-  y += 5;
-
-  y += 6;
-
-  // ── Footer ───────────────────────────────────────────────
-  const pageCount = doc.getNumberOfPages();
-  for (let i = 1; i <= pageCount; i++) {
-    doc.setPage(i);
-    setFont('normal', 7);
-    doc.setTextColor(160,160,160);
-    text(`Erstellt mit abi-rechner.fari-software.de · ${today} · Seite ${i} / ${pageCount}`, W / 2, 290, { align: 'center' });
-    text('⚠ Kein offizielles Dokument. Maßgeblich ist die Prüfungsordnung deiner Schule.', W / 2, 294, { align: 'center' });
+  // Draw merged AF cells
+  for (const reg of afRegions) {
+    const afH = reg.y1-reg.y0;
+    fr(ML, reg.y0, COL.fach-ML, afH, [241,245,249]);
+    lw(0.3); br(ML, reg.y0, COL.fach-ML, afH, [100,100,140]);
+    const lines = afLabelMap[reg.af]||[reg.af];
+    const lineH = 3.2;
+    let ty = reg.y0+(afH-lines.length*lineH)/2+lineH;
+    for (let li=0; li<lines.length; li++) {
+      sf(li===0?'bold':'normal', li===0?7:6);
+      tc(li===0?[30,64,175]:[60,60,60]);
+      tx(lines[li], ML+(COL.fach-ML)/2, ty, { align:'center' });
+      ty += lineH;
+    }
+    tc([0,0,0]);
   }
 
-  doc.save(`wahlbogen-abi2028-${today.replace(/\./g, '-')}.pdf`);
+  // Outer table border
+  const tableY0 = pfY1+4+TH;
+  lw(0.4); br(ML, tableY0, CW, y-tableY0, [0,0,0]);
+  br(ML, tableY0-TH, CW, TH, [0,0,0]);
+
+  y += 3;
+
+  // ══ SUMME ════════════════════════════════════════════════════
+  const totalCourses = studentSubs.reduce((s,sub)=>s+sub.hj,0);
+  const ok40 = totalCourses >= 40;
+  lw(0.3);
+  fr(ML, y, CW, 6.5, ok40?[220,252,231]:[254,243,199]);
+  br(ML, y, CW, 6.5, [0,0,0]);
+  sf('bold', 8);
+  tc(ok40?[22,101,52]:[146,64,14]);
+  tx('Summen', ML+2, y+4.5);
+  tx((ok40?'✓ ':'⚠ ')+totalCourses+' Kurse '+(ok40?'(≥ 40)':'(mind. 40 erforderlich)'), ML+20, y+4.5);
+  tc([0,0,60]);
+  tx('3 L', COL.lb+mid(0,COL.sm-COL.lb), y+4.5, { align:'center' });
+  tx('5 P', COL.sm+mid(0,COL.j11-COL.sm), y+4.5, { align:'center' });
+  tc([0,0,0]);
+  y += 9;
+
+  // ══ FUSSNOTEN ════════════════════════════════════════════════
+  sf('normal', 6); tc([100,100,100]);
+  tx('* Bitte Zuordnung zu einem Aufgabenfeld (I, II, III) angeben.  ** Endgültige Festlegung Ende 3. Kurshalbjahr.  *** Kann 2. Naturwissenschaft ersetzen.', ML, y);
+  y += 3.5;
+  tx('Kein offizielles Dokument — maßgeblich ist allein die aktuelle Prüfungsordnung Ihrer Schule.', ML, y);
+  tc([0,0,0]); y += 7;
+
+  // ══ UNTERSCHRIFT ═════════════════════════════════════════════
+  sf('normal', 8);
+  tx('Ich bestätige die Richtigkeit meiner Angaben.', ML, y);
+  y += 8;
+  const sigW = (CW-10)/2;
+  lw(0.3);
+  ln(ML, y+4, ML+sigW, y+4);
+  ln(ML+sigW+10, y+4, ML+sigW+10+sigW, y+4);
+  sf('normal', 7); tc([100,100,100]);
+  tx('Schüler/in  ·  Datum, Unterschrift', ML, y+7.5);
+  tx('Erziehungsberechtigte/r', ML+sigW+10, y+7.5);
+  tc([0,0,0]);
+
+  // ══ FOOTER ═══════════════════════════════════════════════════
+  const nPages = doc.getNumberOfPages();
+  for (let i=1; i<=nPages; i++) {
+    doc.setPage(i);
+    sf('normal', 6); tc([160,160,160]);
+    tx('Erstellt mit abi-rechner.fari-software.de  ·  '+today+'  ·  Seite '+i+' / '+nPages, W/2, 295, { align:'center' });
+  }
+
+  doc.save('wahlbogen-abi2028-'+today.replace(/\./g,'-')+'.pdf');
   showToast('✓ Wahlbogen-PDF gespeichert');
 }
 </script>

--- a/index.html
+++ b/index.html
@@ -1787,25 +1787,26 @@ function _buildWahlbogenPDF() {
   ];
   while (pruefFaecher.length < 5) pruefFaecher.push({ nr:pruefFaecher.length+1, af:'', name:'', pruef:'', isLF:false });
 
+  const PF_ROW_H = 7;
   for (const pf of pruefFaecher) {
-    fr(ML, y, PF_W, 5.5, pf.nr%2===0?[248,250,252]:[255,255,255]);
+    fr(ML, y, PF_W, PF_ROW_H, pf.nr%2===0?[248,250,252]:[255,255,255]);
     sf('bold', 8); tc([0,0,0]);
-    tx(pf.nr+'.', ML+2, y+4);
+    tx(pf.nr+'.', ML+2, y+4.5);
     sf('normal', 7); tc([80,80,80]);
-    tx(pf.af, ML+10, y+4);
+    tx(pf.af, ML+10, y+4.5);
     sf(pf.isLF?'bold':'normal', 8.5);
     tc(pf.isLF?[30,64,175]:pf.pruef?[60,60,60]:[180,180,180]);
-    tx(pf.name, ML+24, y+4);
+    tx(pf.name, ML+24, y+4.5);
     if (pf.typ) {
-      sf('normal', 6.5);
+      sf('normal', 6);
       tc(pf.isLF?[30,64,175]:[109,40,217]);
-      tx(pf.typ, ML+68, y+2.2);
+      tx(pf.typ, ML+68, y+2.8);
       sf('bold', 7);
-      tx(pf.pruef, ML+68, y+5.2);
+      tx(pf.pruef, ML+68, y+5.5);
     }
     tc([0,0,0]); lw(0.15);
-    ln(ML, y+5.5, ML+PF_W, y+5.5, [200,200,200]);
-    y += 5.5;
+    ln(ML, y+PF_ROW_H, ML+PF_W, y+PF_ROW_H, [200,200,200]);
+    y += PF_ROW_H;
   }
   const pfY1 = y;
 
@@ -1989,18 +1990,7 @@ function _buildWahlbogenPDF() {
   tx('Kein offizielles Dokument — maßgeblich ist allein die aktuelle Prüfungsordnung Ihrer Schule.', ML, y);
   tc([0,0,0]); y += 7;
 
-  // ══ UNTERSCHRIFT ═════════════════════════════════════════════
-  sf('normal', 8);
-  tx('Ich bestätige die Richtigkeit meiner Angaben.', ML, y);
-  y += 8;
-  const sigW = (CW-10)/2;
-  lw(0.3);
-  ln(ML, y+4, ML+sigW, y+4);
-  ln(ML+sigW+10, y+4, ML+sigW+10+sigW, y+4);
-  sf('normal', 7); tc([100,100,100]);
-  tx('Schüler/in  ·  Datum, Unterschrift', ML, y+7.5);
-  tx('Erziehungsberechtigte/r', ML+sigW+10, y+7.5);
-  tc([0,0,0]);
+
 
   // ══ FOOTER ═══════════════════════════════════════════════════
   const nPages = doc.getNumberOfPages();


### PR DESCRIPTION
## Wahlbogen PDF Export

Schüler können jetzt ihre Kurswahl als strukturiertes PDF exportieren — ähnlich dem schulischen Wahlbogen.

### Was ist drin?
- Leerfelder für Name, Klasse, Schule, Unterschriften
- Prüfungsfächer (LF1–3 + mPF1–2) mit Aufgabenfeld und Art
- Vollständige Block-I-Fächerliste:
  - Typ-Badge (LF / BF / PF / PF* / WF)
  - HJ-Kästchen: ✓ = Pflicht-HJ, □ = optional, grau = außerhalb Belegung
  - Anzahl Kurse pro Fach
  - Bemerkungen (Seminare, mind. X HJ)
- Kursanzahl-Summe mit ✓-Marker wenn ≥ 40
- Footer mit Datum + Disclaimer auf jeder Seite

### Kein Server nötig
jsPDF wird on-demand per CDN (jsDelivr) geladen — nur beim ersten Klick. Danach alles lokal.

### Keine Noten
Bewusst: Das PDF zeigt nur die Kurswahl, keine Noten.

Closes #57