### PR TITLE
feat: Feedback-Button hinzufügen

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -74,7 +74,18 @@
     </div>
 
     <div class="bg-white rounded-xl shadow p-6 space-y-3">
-      <h2 class="font-bold text-blue-800 text-lg">4. Keine weiteren Datenerhebungen</h2>
+      <h2 class="font-bold text-blue-800 text-lg">4. Freiwilliges Feedback-Formular</h2>
+      <p>Auf dieser Website gibt es einen optionalen <strong>Feedback-Button</strong>, der zu einem anonymen Formular auf <strong>nextcloud.fari.software</strong> führt (betrieben von der Fari Software GmbH). Die Nutzung ist vollständig freiwillig.</p>
+      <ul class="list-disc list-inside space-y-1 text-sm text-gray-600">
+        <li>Das Formular wird in einem neuen Tab geöffnet – es werden keine Daten automatisch übertragen.</li>
+        <li>Es werden keine personenbezogenen Daten abgefragt. Das Formular ist anonym.</li>
+        <li>Deine Angaben werden ausschließlich zur Verbesserung des Rechners verwendet.</li>
+      </ul>
+      <p class="text-sm text-gray-500">Rechtsgrundlage (sofern du das Formular absendest): Einwilligung gemäß Art. 6 Abs. 1 lit. a DSGVO.</p>
+    </div>
+
+    <div class="bg-white rounded-xl shadow p-6 space-y-3">
+      <h2 class="font-bold text-blue-800 text-lg">5. Keine weiteren Datenerhebungen</h2>
       <p>Diese Website verwendet:</p>
       <ul class="list-disc list-inside space-y-1 text-sm text-gray-600">
         <li>Keine Cookies außer dem Matomo-Opt-Out-Cookie (sofern gesetzt)</li>
@@ -86,13 +97,13 @@
     </div>
 
     <div class="bg-white rounded-xl shadow p-6 space-y-3">
-      <h2 class="font-bold text-blue-800 text-lg">5. Deine Rechte</h2>
+      <h2 class="font-bold text-blue-800 text-lg">6. Deine Rechte</h2>
       <p>Du hast gemäß DSGVO das Recht auf Auskunft, Berichtigung, Löschung, Einschränkung der Verarbeitung sowie das Recht auf Datenübertragbarkeit. Da wir keine personenbezogenen Daten auf unseren Servern speichern (außer anonymisierten Matomo-Statistiken), sind diese Rechte in der Praxis ohne praktische Auswirkung.</p>
       <p>Bei Fragen: <a href="mailto:info@fari-software.de" class="text-blue-700 underline">info@fari-software.de</a></p>
     </div>
 
     <div class="bg-white rounded-xl shadow p-6 space-y-2">
-      <h2 class="font-bold text-blue-800 text-lg">6. Beschwerderecht</h2>
+      <h2 class="font-bold text-blue-800 text-lg">7. Beschwerderecht</h2>
       <p>Du hast das Recht, dich bei einer Datenschutz-Aufsichtsbehörde zu beschweren. Zuständig für die Fari Software GmbH ist der <strong>Landesbeauftragter für den Datenschutz und die Informationsfreiheit Baden-Württemberg</strong>.</p>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -174,6 +174,11 @@
               class="flex items-center gap-1.5 bg-white/10 hover:bg-white/20 text-white text-sm font-semibold px-3 py-1.5 rounded-lg transition-colors">
         🗑️ Zurücksetzen
       </button>
+      <a href="https://nextcloud.fari.software/apps/forms/s/7XpGKBNm6LD6fbCxixEWT63D"
+         target="_blank" rel="noopener noreferrer"
+         class="flex items-center gap-1.5 bg-green-600 hover:bg-green-500 text-white text-sm font-semibold px-3 py-1.5 rounded-lg transition-colors">
+        💬 Feedback
+      </a>
     </div>
   </div>
 </header>


### PR DESCRIPTION
Feedback-Button im Header von index.html hinzugefügt (links neben Zurücksetzen). Öffnet das anonyme Nextcloud-Formular in neuem Tab. Datenschutzerklärung um Abschnitt zum freiwilligen Feedback-Formular ergänzt.

Closes #60

Generated with [Claude Code](https://claude.ai/code)