### PR TITLE
Remove "2028 only" hints from all user-facing text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Zum [Rechner](https://farisoftware.github.io/abi-rechner/)
 
-# Abitur BW 2028 – Notenrechner
+# Abitur BW – Notenrechner
 
-Kurs- & Notenrechner für die gymnasiale Qualifikationsphase in Baden-Württemberg (Abitur 2028).
+Kurs- & Notenrechner für die gymnasiale Qualifikationsphase in Baden-Württemberg.
 
 ## Features
 

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Datenschutzerklärung – Abitur BW 2028 Notenrechner</title>
+  <title>Datenschutzerklärung – Abitur BW Notenrechner</title>
   <meta name="robots" content="noindex, follow" />
   <link rel="canonical" href="https://farisoftware.github.io/abi-rechner/datenschutz.html" />
   <link rel="stylesheet" href="tailwind.css" />

--- a/impressum.html
+++ b/impressum.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Impressum – Abitur BW 2028 Notenrechner</title>
+  <title>Impressum – Abitur BW Notenrechner</title>
   <meta name="robots" content="noindex, follow" />
   <link rel="canonical" href="https://farisoftware.github.io/abi-rechner/impressum.html" />
   <link rel="stylesheet" href="tailwind.css" />

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Abitur BW 2028 – Kurswahl & Notenrechner für Baden-Württemberg</title>
-  <meta name="description" content="Kostenloser Abitur-Rechner für Baden-Württemberg 2028: Kurswahl planen, Block I & Block II berechnen und Abiturnote ermitteln — kein Login, alles lokal im Browser." />
+  <title>Abitur BW – Kurswahl & Notenrechner für Baden-Württemberg</title>
+  <meta name="description" content="Kostenloser Abitur-Rechner für Baden-Württemberg: Kurswahl planen, Block I & Block II berechnen und Abiturnote ermitteln — kein Login, alles lokal im Browser." />
 
   <!-- Canonical -->
   <link rel="canonical" href="https://farisoftware.github.io/abi-rechner/" />
@@ -12,8 +12,8 @@
   <!-- Open Graph -->
   <meta property="og:type"        content="website" />
   <meta property="og:url"         content="https://farisoftware.github.io/abi-rechner/" />
-  <meta property="og:title"       content="Abitur BW 2028 – Kurswahl & Notenrechner" />
-  <meta property="og:description" content="Kostenloser Abitur-Rechner für Baden-Württemberg 2028: Kurswahl planen, Block I & Block II berechnen und Abiturnote ermitteln — kein Login, alles lokal im Browser." />
+  <meta property="og:title"       content="Abitur BW – Kurswahl & Notenrechner" />
+  <meta property="og:description" content="Kostenloser Abitur-Rechner für Baden-Württemberg: Kurswahl planen, Block I & Block II berechnen und Abiturnote ermitteln — kein Login, alles lokal im Browser." />
   <meta property="og:image"       content="https://farisoftware.github.io/abi-rechner/og-image.png" />
   <meta property="og:image:width"  content="1200" />
   <meta property="og:image:height" content="630" />
@@ -24,17 +24,17 @@
   <!-- Twitter / X Card -->
   <meta name="twitter:card"        content="summary_large_image" />
   <meta name="twitter:image"       content="https://farisoftware.github.io/abi-rechner/og-image.png" />
-  <meta name="twitter:title"       content="Abitur BW 2028 – Kurswahl & Notenrechner" />
-  <meta name="twitter:description" content="Kostenloser Abitur-Rechner für Baden-Württemberg 2028: Kurswahl planen, Block I & Block II berechnen und Abiturnote ermitteln." />
+  <meta name="twitter:title"       content="Abitur BW – Kurswahl & Notenrechner" />
+  <meta name="twitter:description" content="Kostenloser Abitur-Rechner für Baden-Württemberg: Kurswahl planen, Block I & Block II berechnen und Abiturnote ermitteln." />
 
   <!-- JSON-LD: WebApplication -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "WebApplication",
-    "name": "Abitur BW 2028 – Kurswahl & Notenrechner",
+    "name": "Abitur BW – Kurswahl & Notenrechner",
     "url": "https://farisoftware.github.io/abi-rechner/",
-    "description": "Kostenloser Abitur-Rechner für Baden-Württemberg 2028: Kurswahl planen, Block I & Block II berechnen und Abiturnote ermitteln.",
+    "description": "Kostenloser Abitur-Rechner für Baden-Württemberg: Kurswahl planen, Block I & Block II berechnen und Abiturnote ermitteln.",
     "applicationCategory": "EducationalApplication",
     "operatingSystem": "Any",
     "offers": {
@@ -63,7 +63,7 @@
     "mainEntity": [
       {
         "@type": "Question",
-        "name": "Wie berechnet sich die Abiturnote in Baden-Württemberg 2028?",
+        "name": "Wie berechnet sich die Abiturnote in Baden-Württemberg?",
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "Die Abiturnote setzt sich aus zwei Blöcken zusammen: Block I (Kursnoten aus den vier Halbjahren, max. 600 Punkte) und Block II (Abiturprüfungen, max. 300 Punkte). Insgesamt sind maximal 900 Punkte möglich, die in eine Note von 1,0 bis 4,0 umgerechnet werden."
@@ -215,7 +215,7 @@
 <header class="bg-blue-800 text-white shadow-lg">
   <div class="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between gap-4 flex-wrap">
     <div>
-      <h1 class="text-xl font-bold">🎓 Abitur BW 2028 – Notenrechner</h1>
+      <h1 class="text-xl font-bold">🎓 Abitur BW – Notenrechner</h1>
       <p class="text-blue-200 text-sm mt-0.5">Deine Fächer und Noten bleiben lokal in deinem Browser</p>
     </div>
     <div class="flex items-center gap-2">
@@ -435,10 +435,10 @@
 
 <!-- ══ SEO CONTENT & FAQ ══ -->
 <section class="max-w-7xl mx-auto px-4 mt-10 mb-6">
-  <h2 class="text-lg font-bold text-gray-700 mb-2">Kurswahl und Abiturnote berechnen — Abitur BW 2028</h2>
+  <h2 class="text-lg font-bold text-gray-700 mb-2">Kurswahl und Abiturnote berechnen — Abitur BW</h2>
   <p class="text-sm text-gray-500 mb-6 max-w-3xl">
     Dieser Abitur-Rechner hilft dir bei der Kurswahl und der Berechnung deiner Abiturnote nach der aktuellen Verordnung
-    für Baden-Württemberg (Abitur 2028). Wähle deine Prüfungsfächer, trage deine Halbjahresleistungen ein und sieh
+    für Baden-Württemberg. Wähle deine Prüfungsfächer, trage deine Halbjahresleistungen ein und sieh
     sofort, wie sich Block&nbsp;I, Block&nbsp;II und deine Gesamtpunktzahl zusammensetzen.
   </p>
 
@@ -446,7 +446,7 @@
   <div class="space-y-2 max-w-3xl">
     <details class="group border border-gray-200 rounded-lg">
       <summary class="flex items-center justify-between cursor-pointer px-4 py-3 text-sm font-semibold text-gray-700 hover:bg-gray-50">
-        Wie berechnet sich die Abiturnote in BW 2028?
+        Wie berechnet sich die Abiturnote in BW?
         <span class="ml-2 text-gray-400 group-open:rotate-180 transition-transform">&#9662;</span>
       </summary>
       <p class="px-4 pb-3 text-sm text-gray-500">


### PR DESCRIPTION
Remove all references suggesting the calculator is only valid for Abitur 2028. The Abi Rechner is valid for all Abitur in Baden-Württemberg.

Changes:
- Page titles, meta descriptions, Open Graph and Twitter Card tags
- JSON-LD structured data
- App header h1 and section headings
- FAQ question text
- README title and description

The footer citation of the official KM BW document ("Leitfaden Abitur BW 2028") is kept as a factual reference to the source material.

Closes #80

Generated with [Claude Code](https://claude.ai/code)